### PR TITLE
Add links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ support bootstrapping a CloudFoundry installation on AWS.
 ## Guides
 
 - [Getting Started on AWS](docs/getting-started-aws.md)
+- [Deploying Concourse on GCP](concourse.md)
+- [Deploying Cloud Foundry on GCP](cloudfoundry.md)
 
 ## Prerequisites
 


### PR DESCRIPTION
Link concourse.md and cloudfoundry.md for easier discoverability.

Might also consider moving these two files to the `docs/` folder with the AWS guide.